### PR TITLE
Fix for StrictMode

### DIFF
--- a/src/com/android/debug/hv/ViewServer.java
+++ b/src/com/android/debug/hv/ViewServer.java
@@ -64,17 +64,17 @@ import android.view.ViewDebug;
  *     public void onCreate(Bundle savedInstanceState) {
  *         super.onCreate(savedInstanceState);
  *         // Set content view, etc.
- *         ViewServer.get().addWindow(this);
+ *         ViewServer.get(this).addWindow(this);
  *     }
  *       
  *     public void onDestroy() {
  *         super.onDestroy();
- *         ViewServer.get().removeWindow(this);
+ *         ViewServer.get(this).removeWindow(this);
  *     }
  *   
  *     public void onResume() {
  *         super.onResume();
- *         ViewServer.get().setFocusedWindow(this);
+ *         ViewServer.get(this).setFocusedWindow(this);
  *     }
  * }
  * </pre>


### PR DESCRIPTION
Hi,

I made a change that would prevent the StrictMode Exception when you are using the ViewServer on Honeycomb or later.
I moved the creation of the ServerSocket to the ViewServer thread so that it's not running on the main UI thread. 
