### PR TITLE
Use BuildConfig.DEBUG instead of "debuggable"

### DIFF
--- a/src/com/android/debug/hv/ViewServer.java
+++ b/src/com/android/debug/hv/ViewServer.java
@@ -36,7 +36,6 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import android.app.Activity;
 import android.content.Context;
-import android.content.pm.ApplicationInfo;
 import android.os.Build;
 import android.text.TextUtils;
 import android.util.Log;
@@ -163,9 +162,7 @@ public class ViewServer implements Runnable {
      *                debuggable, this can be the application context
      */
     public static ViewServer get(Context context) {
-        ApplicationInfo info = context.getApplicationInfo();
-        if (BUILD_TYPE_USER.equals(Build.TYPE) &&
-                (info.flags & ApplicationInfo.FLAG_DEBUGGABLE) != 0) {
+        if (BUILD_TYPE_USER.equals(Build.TYPE) && BuildConfig.DEBUG) {
             if (sServer == null) {
                 sServer = new ViewServer(ViewServer.VIEW_SERVER_DEFAULT_PORT);
             }


### PR DESCRIPTION
While Eclipse/ADT manages "debuggable" automatically [1], other build tools don't (eg android-maven-plugin).
That being said, switching to  BuildConfig.DEBUG also makes it less likely for one to release a production build with "debuggable"=true, as users won't be required to hardcode debuggable=true on their app manifests.

[1] according to http://stackoverflow.com/questions/4580595/what-would-happen-if-android-app-is-released-with-debuggable-on
