### PR TITLE
Clear mFocusedWindow on destroy

### DIFF
--- a/viewserver/src/main/java/com/android/debug/hv/ViewServer.java
+++ b/viewserver/src/main/java/com/android/debug/hv/ViewServer.java
@@ -342,11 +342,21 @@ public class ViewServer implements Runnable {
      * @see #addWindow(View, String)
      */
     public void removeWindow(View view) {
+        View rootView;
         mWindowsLock.writeLock().lock();
         try {
-            mWindows.remove(view.getRootView());
+            rootView = view.getRootView();
+            mWindows.remove(rootView);
         } finally {
             mWindowsLock.writeLock().unlock();
+        }
+        mFocusLock.writeLock().lock();
+        try {
+            if (mFocusedWindow == rootView) {
+                mFocusedWindow = null;
+            }
+        } finally {
+            mFocusLock.writeLock().unlock();
         }
         fireWindowsChangedEvent();
     }


### PR DESCRIPTION
Don't leak activity if no other activity replaces the one that's destroyed.